### PR TITLE
fix: uppercase Button size prop for Strapi 5.35+ compatibility

### DIFF
--- a/admin/src/components/Input.tsx
+++ b/admin/src/components/Input.tsx
@@ -102,7 +102,7 @@ const Input: React.FC<InputProps> = ({ hint, labelAction, label, name, required,
 
         <Box style={{ display: 'grid', gridTemplateColumns: '4fr 1fr', gap: '8px' }}>
           <TextInput ref={searchRef} name="search" placeholder="Address to search" />
-          <Button onClick={searchLocation} size="l">
+          <Button onClick={searchLocation} size="L">
             Search
           </Button>
         </Box>


### PR DESCRIPTION
## Summary

- Fix `Button` `size` prop from lowercase `"l"` to uppercase `"L"` in `Input.tsx`

## Problem

Starting with Strapi 5.35.0, the Design System theme defines button sizes as uppercase keys (`"S"`, `"M"`, `"L"`). The `Button` component in `Input.tsx` uses `size="l"` (lowercase), which causes `theme.sizes.button["l"]` to return `undefined`. This leads to `Object.entries(undefined)` throwing:

```
TypeError: Cannot convert undefined or null to object
```

This crash breaks the entire edit view for any content type that uses the location picker field.

## Fix

Changed `size="l"` to `size="L"` in `admin/src/components/Input.tsx` line 105.

## Test plan

- [x] Install plugin in Strapi 5.35.0+ project
- [x] Open any content type entry with a location picker field
- [x] Verify the edit view loads without error
- [x] Verify the Search button renders and functions correctly